### PR TITLE
gcloud components update `--quiet`

### DIFF
--- a/zsh/bin/upgrade_system_deps.zsh
+++ b/zsh/bin/upgrade_system_deps.zsh
@@ -16,7 +16,7 @@ if command -v flutter &> /dev/null; then
 fi
 
 if command -v gcloud &> /dev/null; then
-  gcloud components update
+  gcloud components update --quiet
 fi
 
 if command -v gem &> /dev/null; then


### PR DESCRIPTION
See: `gcloud help`

>       --quiet, -q
>         Disable all interactive prompts when running gcloud commands. If input
>         is required, defaults will be used, or an error will be raised.
> 
>         Overrides the default core/disable_prompts property value for this
>         command invocation. This is equivalent to setting the environment
>         variable CLOUDSDK_CORE_DISABLE_PROMPTS to 1.