### PR TITLE
resolve brew doctor issue

### DIFF
--- a/zsh/.path.zsh
+++ b/zsh/.path.zsh
@@ -3,6 +3,7 @@ export PATH=$PATH:$HOME/dotfiles/zsh/bin
 
 # brew
 export HOMEBREW_BUNDLE_FILE="$HOME/dotfiles/Brewfile"
+export PATH="/usr/local/sbin:$PATH"
 
 # use diff-highlight with git
 export PATH=$PATH:/usr/local/share/git-core/contrib/diff-highlight


### PR DESCRIPTION
```
$ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Homebrew's "sbin" was not found in your PATH but you have installed
formulae that put executables in /usr/local/sbin.
Consider setting your PATH for example like so:
  echo 'export PATH="/usr/local/sbin:$PATH"' >> ~/.zshrc
zsh: exit 1     brew doctor
```