### PR TITLE
update brew bin path

### DIFF
--- a/macos/.path.zsh
+++ b/macos/.path.zsh
@@ -5,4 +5,4 @@
 export PATH=$PATH:$HOME/dotfiles/macos/bin
 
 # brew
-export PATH=$PATH:/opt/homebrew/bin
+export PATH=/opt/homebrew/bin:$PATH


### PR DESCRIPTION
```
Warning: /usr/bin occurs before /opt/homebrew/bin in your PATH.
This means that system-provided programs will be used instead of those
provided by Homebrew. Consider setting your PATH so that
/opt/homebrew/bin occurs before /usr/bin. Here is a one-liner:
  echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.zshrc
````