### PR TITLE
use github actions runner `macos-latest-xl`

### DIFF
--- a/.github/workflows/setup_machine.yaml
+++ b/.github/workflows/setup_machine.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       # fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-latest-xl]
     timeout-minutes: 60
     steps:
       - name: workaround setup for github runner macos


### PR DESCRIPTION
- https://docs.github.com/ja/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
- https://github.blog/2023-03-01-github-actions-introducing-faster-github-hosted-x64-macos-runners/