### PR TITLE
add `macos-latest-xlarge`

### DIFF
--- a/.github/workflows/setup_machine.yaml
+++ b/.github/workflows/setup_machine.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       # fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-latest, macos-latest-xlarge]
     timeout-minutes: 60
     steps:
       - name: workaround setup for github runner macos


### PR DESCRIPTION
https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/